### PR TITLE
fix: add ability to add product to taxons

### DIFF
--- a/app/overrides/spree/api/V2/platform/products_controller_decorator.rb
+++ b/app/overrides/spree/api/V2/platform/products_controller_decorator.rb
@@ -1,6 +1,6 @@
 module Spree::Api::V2::Platform::ProductsControllerDecorator
   def spree_permitted_attributes
-    super.push(:price)
+    super.push(:price,:taxon_ids)
   end
 end
 


### PR DESCRIPTION
## Description

The api doesn't support attaching products to taxons. This is because `taxon_ids` isn't a column on products table. Adding it to list of permitted attributes solves this issue.

Please, provide here a short description.
Consider including things like:
- An overview of why the work is taking place (with any relevant links); don’t assume familiarity with the history.
- Major changes made and a high-level idea of the chosen approach.
- All the compromises made (in _performance, readability, maintainability etc._)
  to achieve the expected result if any

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
